### PR TITLE
bind sur localhost

### DIFF
--- a/config/mysql/my.cnf
+++ b/config/mysql/my.cnf
@@ -19,6 +19,7 @@
 #password	= your_password
 port		= 3306
 socket		= /var/run/mysqld/mysqld.sock
+bind-address = 127.0.0.1
 
 # Here follows entries for some specific programs
 


### PR DESCRIPTION
Par défaut bind sur 0.0.0.0 (accessible depuis l'extérieur), est-ce vraiment nécessaire ? Si non, bind sur localhost