### PR TITLE
bind sur localhost dans la section mysqld

### DIFF
--- a/config/mysql/my.cnf
+++ b/config/mysql/my.cnf
@@ -27,6 +27,7 @@ bind-address = 127.0.0.1
 [mysqld]
 port		= 3306
 socket		= /var/run/mysqld/mysqld.sock
+bind-address = 127.0.0.1
 skip-external-locking
 key_buffer_size = 16K
 max_allowed_packet = 1M


### PR DESCRIPTION
le précédent patch ne faisait qu'indiquer aux clients vers qui se bind-er, le démon restait sur 0.0.0.0