### PR TITLE
Avoid self corruption of mysql on power failure

### DIFF
--- a/config/mysql/my.cnf
+++ b/config/mysql/my.cnf
@@ -37,6 +37,9 @@ read_rnd_buffer_size = 256K
 net_buffer_length = 2K
 thread_stack = 128K
 
+# to avoid corruption on powerfailure
+default-storage-engine=innodb
+
 # Don't listen on a TCP/IP port at all. This can be a security enhancement,
 # if all processes that need to connect to mysqld run on the same host.
 # All interaction with mysqld must be made via Unix sockets or named pipes.


### PR DESCRIPTION
By default, mysql creates its mysql database in MyISAN mode which self corrupt itself way too frequently on the internet cube configuration. InnoDB seems fine in comparison. Also MyISAN is bullcrap.